### PR TITLE
[release-branch.go1.21] cmd/internal/obj: hack FENCETSO to make it "f…

### DIFF
--- a/src/cmd/internal/obj/riscv/inst.go
+++ b/src/cmd/internal/obj/riscv/inst.go
@@ -182,7 +182,9 @@ func encode(a obj.As) *inst {
 	case AFENCE:
 		return &inst{0xf, 0x0, 0x0, 0, 0x0}
 	case AFENCETSO:
-		return &inst{0xf, 0x0, 0x13, -1997, 0x41}
+		// https://github.com/revyos/revyos/issues/22
+		// encode "fence rw, rw" instead
+		return &inst{0xf, 0x0, 0x13, 51, 0x1}
 	case AFEQD:
 		return &inst{0x53, 0x2, 0x0, -1504, 0x51}
 	case AFEQQ:


### PR DESCRIPTION
…ence rw, rw" instead

It is said that T-Head C910/C906 are early designs that don't support fence.tso natively, so we would want to avoid emitting it because SBI emulation is slow.

This is not currently used at present, but preemptively patch it so we won't have to revisit this in the future.

The change is a hack, because the RevyOS Go fork is only intended to be used with T-Head systems.

Closes: https://github.com/revyos/revyos/issues/22
Change-Id: I8107e3bd2d9c208cd0606f09b984ad59eb75010e

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
